### PR TITLE
Task to export client JS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,10 @@ gem 'spring',        group: :development
 
 gem 'rack-cors', :require => 'rack/cors'
 
+group :development, :test do
+  gem 'debugger'
+end
+
 group :test do
   gem 'nokogiri'
   gem 'mocha'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,13 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.7.0)
+    columnize (0.8.9)
+    debugger (1.6.6)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.3.2)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.3.2)
     erubis (2.7.0)
     execjs (2.0.2)
     hike (1.2.3)
@@ -147,6 +154,7 @@ DEPENDENCIES
   capistrano-bundler (~> 1.1)
   capistrano-rails (~> 1.1)
   coffee-rails (~> 4.0.0)
+  debugger
   jquery-rails
   mocha
   nokogiri

--- a/app/assets/javascripts/journeys_client.js
+++ b/app/assets/javascripts/journeys_client.js
@@ -1,0 +1,1 @@
+//= require ./journeys_client.js.coffee

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,10 +5,6 @@
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
-
-  <script type="text/javascript">
-    Journeys.post();
-  </script>
 </head>
 <body>
 

--- a/client_lib/journeys_client.js
+++ b/client_lib/journeys_client.js
@@ -1,0 +1,1 @@
+(function(){var t;t="http://stage.journ.cyanoryx.com",window.Journeys={post:function(){var n;return n={slug:document.URL},$.ajax({type:"POST",url:""+t+"/events",data:JSON.stringify(n),contentType:"application/json; charset=utf-8"})}}}).call(this);

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,3 +13,7 @@ development:
 test:
   <<: *default
   database: "journeys_test"
+
+production:
+  <<: *default
+  database: "journeys_development"

--- a/lib/tasks/compile_journeys_client.rake
+++ b/lib/tasks/compile_journeys_client.rake
@@ -1,0 +1,17 @@
+require 'sprockets'
+
+namespace :assets do
+  namespace :precompile do
+    desc "Compile journeys JS client"
+    task :journeys_client => :environment do 
+      Rake::SprocketsTask.new(:journeys_client) do |t|
+        t.environment = Rails.application.assets
+        t.output      = "./client_lib"
+        debugger
+        t.assets      = %w( journeys_client.js )
+      end
+
+      Rake::Task["journeys_client"].execute
+    end
+  end
+end

--- a/lib/tasks/compile_journeys_client.rake
+++ b/lib/tasks/compile_journeys_client.rake
@@ -17,8 +17,17 @@ namespace :assets do
         if file_matcher.match(file_name)
           target = "#{OUTPUT_DIR}#{OUTPUT_FILENAME}"
 
-          FileUtils.move( file_name, target)
+          FileUtils.mv(
+            file_name,
+            target
+          )
+          puts "Wrote client to #{target}"
 
+
+          FileUtils.cp(
+            target,
+            "./public/#{OUTPUT_FILENAME}"
+          )
           puts "Wrote client to #{target}"
         else
           File.delete(file_name)

--- a/lib/tasks/compile_journeys_client.rake
+++ b/lib/tasks/compile_journeys_client.rake
@@ -1,13 +1,37 @@
 require 'sprockets'
+require 'fileutils'
+
+OUTPUT_DIR = "./client_lib/"
+OUTPUT_FILENAME = "journeys_client.js"
 
 namespace :assets do
   namespace :precompile do
     desc "Compile journeys JS client"
     task :journeys_client => :environment do 
+      `RAILS_ENV=production bundle exec rake assets:precompile:internal_journey_client`
+
+      files = Dir.glob("#{OUTPUT_DIR}*")
+
+      file_matcher = /journeys_client.*.js$/
+      files.each do |file_name|
+        if file_matcher.match(file_name)
+          target = "#{OUTPUT_DIR}#{OUTPUT_FILENAME}"
+
+          FileUtils.move( file_name, target)
+
+          puts "Wrote client to #{target}"
+        else
+          File.delete(file_name)
+        end
+      end
+    end
+
+    desc "Internal BIG HAX compiler because sprockets is unintelligable"
+    task :internal_journey_client => :environment do
       Rake::SprocketsTask.new(:journeys_client) do |t|
         t.environment = Rails.application.assets
+
         t.output      = "./client_lib"
-        debugger
         t.assets      = %w( journeys_client.js )
       end
 

--- a/public/journeys_client.js
+++ b/public/journeys_client.js
@@ -1,0 +1,1 @@
+(function(){var t;t="http://stage.journ.cyanoryx.com",window.Journeys={post:function(){var n;return n={slug:document.URL},$.ajax({type:"POST",url:""+t+"/events",data:JSON.stringify(n),contentType:"application/json; charset=utf-8"})}}}).call(this);


### PR DESCRIPTION
This is really awful stuff, sprockets is not designed to be used like this :-| But it works. I've added the Journey.post() code to a bunch of sites, downloading the script from the /public directory in the deployed app. Seems to work, we'll see if we actually have any sites with enough traffic to actually generate some useful data.
